### PR TITLE
test: CXTB-293 notifications page

### DIFF
--- a/lib/core/device.rb
+++ b/lib/core/device.rb
@@ -1849,6 +1849,27 @@ def generate_unique_name(action)
   ENV[convert_value(action["ResultVar"])] = unique_name
 end
 
+# Custom method to calculate the minutes/seconds from when an event was created
+# i.e. returns "Added x minutes ago" or "Added x seconds ago"
+def calculate_minutes_passed_by_from_event_creation(action)
+  timestamp = Time.parse(convert_value(action["Timestamp"]))
+  now = Time.now.getlocal
+  diff = now - timestamp
+  
+  if diff < 60
+    seconds_passed = diff.truncate()
+    ENV[convert_value(action["ResultVar"])] = "Added #{seconds_passed} seconds ago"
+  else
+    minutes_passed = (diff/60).truncate()
+    if minutes_passed == 1
+      ENV[convert_value(action["ResultVar"])] = "Added #{minutes_passed} minute ago"
+    else
+      ENV[convert_value(action["ResultVar"])] = "Added #{minutes_passed} minutes ago"
+    end
+  end
+  
+end
+
 # Custom method to verify that an event on Never Alone went to the bottom after its time has passed.
 def verify_event_went_to_bottom(action)
   action = convert_value_pageobjects(action);

--- a/tests/cases/helpers/case_helpers_care_platform.yaml
+++ b/tests/cases/helpers/case_helpers_care_platform.yaml
@@ -200,6 +200,10 @@ SetScheduledCallForSeniors:
     - Type: wait_for
       Strategy: xpath
       Id: $PAGE.care_platform_notifications.event_created_notification$
+    # Get timestamp where event was sent to Senior.
+    - Type: get_local_timestamp
+      Format: "%c"
+      Var: EVENT_SENT_TIMESTAMP
     # Navigate back to home 
     - Type: click
       Strategy: xpath

--- a/tests/cases/seniors_app/case_seniors_app_notifications.yaml
+++ b/tests/cases/seniors_app/case_seniors_app_notifications.yaml
@@ -13,3 +13,55 @@ TestNotificationsPageNavigation:
   # Terminate the app.
     - Type: case
       Value: TerminateApp
+
+# CXTB-22: Verify Notifications Page
+TestNotificationsPage:
+  Environment: Settings
+  Precases:
+    - LoginNeverAloneHelper
+  Aftercases:
+    - TerminateApp
+  Roles:
+    - Role: localiOS
+      App: NeverAlone
+    - Role: desktopChrome
+      App: desktop    
+  Actions:
+  # In the Home page, click on the Bell icon and verify user is redirected to Notifications page.
+    - Type: case
+      Value: NotificationsPageNavigationHelper
+  # Verify that the number next to notifications header shows he number of the new notifications present.
+  # Get actual number of notifications.
+    - Type: wait_not_visible
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_notifications.no_new_notification$
+      Time: 10
+    - Type: return_element_attribute
+      Strategy: xpath
+      Id: $PAGE.seniors_app_notifications.notifications_number_label$
+      Attribute: label
+      ResultVar: NOTIFICATIONS_NUMBER_LABEL
+  # Add a notification
+    - Type: case
+      Value: SetScheduledCallForSeniors
+  # Verify that there is one more.
+    - Type: sleep
+      Time: 10
+    - Type: operation
+      Operation: "$AND_CLI_NOTIFICATIONS_NUMBER_LABEL$ + 1"
+      ResultVar: UPDATED_NOTIFICATION_NUMBER_LABEL
+    - Type: return_element_attribute
+      Strategy: xpath
+      Id: $PAGE.seniors_app_notifications.notifications_number_label$
+      Attribute: label
+      ResultVar: NOTIFICATIONS_NUMBER_LABEL
+    - Type: assert
+      Asserts:
+        - Type: eq
+          Var: UPDATED_NOTIFICATION_NUMBER_LABEL
+          Value: $AND_CLI_NOTIFICATIONS_NUMBER_LABEL$
+
+  # Click on the notification created on this run.
+  # Verify the notification is not appearing on the "New" tab anymore.
+  # Click on "All" at the top of the page.
+  # Verify that the notification appears on the "All" tab.

--- a/tests/cases/seniors_app/case_seniors_app_notifications.yaml
+++ b/tests/cases/seniors_app/case_seniors_app_notifications.yaml
@@ -90,7 +90,27 @@ TestNotificationsPage:
       Strategy: class_chain
       Id: $PAGE.seniors_app_notifications.appointment_based_on_name_element$
   # Click on the notification.
-    - Type: wait_for
+  # This sleep is to reduce flakyness, if we assert by seconds then there are higher chances that test will fail.
+  # With this sleep we will assert once it has passed a minute and the label says taht was added 1 minute ago.
+    - Type: sleep
+      Time: 55
+    - Type: click
       Strategy: class_chain
       Id: $PAGE.seniors_app_notifications.appointment_based_on_name_element$
   # Verify user can see when it was sent.
+    - Type: wait_for
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_appointment_modal.appointment_added_label$
+    - Type: calculate_minutes_passed_by_from_event_creation
+      Timestamp: $AND_CLI_EVENT_SENT_TIMESTAMP$
+      ResultVar: ADDED_EVENT_X_TIME_AGO
+    - Type: return_element_attribute
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_appointment_modal.appointment_added_label$
+      Attribute: label
+      ResultVar: APPOINTMENT_ADDED_X_TIME_AGO
+    - Type: assert
+      Asserts:
+        - Type: eq
+          Var: APPOINTMENT_ADDED_X_TIME_AGO
+          Value: $AND_CLI_ADDED_EVENT_X_TIME_AGO$

--- a/tests/cases/seniors_app/case_seniors_app_notifications.yaml
+++ b/tests/cases/seniors_app/case_seniors_app_notifications.yaml
@@ -14,8 +14,8 @@ TestNotificationsPageNavigation:
     - Type: case
       Value: TerminateApp
 
-# CXTB-22: Verify Notifications Page
-TestNotificationsPage:
+# CXTB-22: Verify Notifications Page on Senior App
+TestNotificationsPageOnSeniorApp:
   Environment: Settings
   Precases:
     - LoginNeverAloneHelper

--- a/tests/cases/seniors_app/case_seniors_app_notifications.yaml
+++ b/tests/cases/seniors_app/case_seniors_app_notifications.yaml
@@ -38,7 +38,7 @@ TestNotificationsPage:
       Id: $PAGE.seniors_app_notifications.notifications_number_label$
       Attribute: label
       ResultVar: NOTIFICATIONS_NUMBER_LABEL
-  # Verify that the number next to notifications header shows he number of the new notifications present.
+  # Verify that the number next to notifications header shows the number of the new notifications present.
   # Add a notification
     - Type: case
       Value: SetScheduledCallForSeniors

--- a/tests/cases/seniors_app/case_seniors_app_notifications.yaml
+++ b/tests/cases/seniors_app/case_seniors_app_notifications.yaml
@@ -30,21 +30,23 @@ TestNotificationsPage:
   # In the Home page, click on the Bell icon and verify user is redirected to Notifications page.
     - Type: case
       Value: NotificationsPageNavigationHelper
-  # Verify that the number next to notifications header shows he number of the new notifications present.
-  # Get actual number of notifications.
-    - Type: wait_not_visible
-      Strategy: class_chain
-      Id: $PAGE.seniors_app_notifications.no_new_notification$
+    - Type: sleep
       Time: 10
+  # Get actual number of notifications.
     - Type: return_element_attribute
       Strategy: xpath
       Id: $PAGE.seniors_app_notifications.notifications_number_label$
       Attribute: label
       ResultVar: NOTIFICATIONS_NUMBER_LABEL
+  # Verify that the number next to notifications header shows he number of the new notifications present.
   # Add a notification
     - Type: case
       Value: SetScheduledCallForSeniors
-  # Verify that there is one more.
+    - Type: wait_not_visible
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_notifications.no_new_notification$
+      Time: 10
+  # Verify that there is one more since there was a new notification added on this run.
     - Type: sleep
       Time: 10
     - Type: operation
@@ -84,5 +86,11 @@ TestNotificationsPage:
       Strategy: class_chain
       Id: $PAGE.seniors_app_notifications.all_tab$
   # Verify that the notification appears under the "All" tab.
+    - Type: wait_for
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_notifications.appointment_based_on_name_element$
   # Click on the notification.
+    - Type: wait_for
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_notifications.appointment_based_on_name_element$
   # Verify user can see when it was sent.

--- a/tests/cases/seniors_app/case_seniors_app_notifications.yaml
+++ b/tests/cases/seniors_app/case_seniors_app_notifications.yaml
@@ -60,8 +60,29 @@ TestNotificationsPage:
         - Type: eq
           Var: UPDATED_NOTIFICATION_NUMBER_LABEL
           Value: $AND_CLI_NOTIFICATIONS_NUMBER_LABEL$
-
   # Click on the notification created on this run.
+    - Type: click
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_notifications.appointment_based_on_name_element$
+    - Type: wait_for
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_appointment_modal.appointment_header_modal$
+    - Type: click
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_appointment_modal.close_btn$
+    - Type: wait_not_visible
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_appointment_modal.appointment_header_modal$
+      Time: 10
   # Verify the notification is not appearing on the "New" tab anymore.
+    - Type: wait_not_visible
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_notifications.appointment_based_on_name_element$
+      Time: 10
   # Click on "All" at the top of the page.
-  # Verify that the notification appears on the "All" tab.
+    - Type: click
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_notifications.all_tab$
+  # Verify that the notification appears under the "All" tab.
+  # Click on the notification.
+  # Verify user can see when it was sent.

--- a/tests/page_objects/seniors_app_page.yaml
+++ b/tests/page_objects/seniors_app_page.yaml
@@ -108,5 +108,9 @@ seniors_app_notifications:
   notifications_label: "**/XCUIElementTypeStaticText[`label == 'Notifications'`]"
   first_notification: "**/XCUIElementTypeScrollView/XCUIElementTypeOther[1]/**/XCUIElementTypeOther[`enabled == 1 AND accessible == 1`][1]"
   close_btn: "**/XCUIElementTypeButton[`label CONTAINS 'Close'`]"
+  no_new_notification: "**/XCUIElementTypeStaticText[`label == 'No new notifications'`]"
+  notifications_number_label: //XCUIElementTypeStaticText[@name='Notifications']/preceding::XCUIElementTypeStaticText
+  all_tab: "**/XCUIElementTypeStaticText[`label == 'All'`]"
+  new_tab: "**/XCUIElementTypeStaticText[`label == 'New'`]"
   appointment_header_modal: "**/XCUIElementTypeStaticText[`label BEGINSWITH 'Appointment'`][-1]"
   appointment_starting_soon_header_modal: "**/XCUIElementTypeStaticText[`label BEGINSWITH 'Appointment' and label ENDSWITH 'Soon'`][-1]"

--- a/tests/page_objects/seniors_app_page.yaml
+++ b/tests/page_objects/seniors_app_page.yaml
@@ -84,6 +84,7 @@ seniors_app_appointment_modal:
   where_label: "**/XCUIElementTypeStaticText[`label == 'Where:'`]"
   description_label: "**/XCUIElementTypeStaticText[`label == 'Description'`]"
   live_label: "**/XCUIElementTypeOther[`label == 'Live'`]"
+  appointment_added_label: "**/XCUIElementTypeStaticText[`label BEGINSWITH 'Added'`]"
 
 seniors_app_connection_error_modal:
   device_offline_label: "**/XCUIElementTypeStaticText[`label == 'Device is offline.'`]"

--- a/tests/page_objects/seniors_app_page.yaml
+++ b/tests/page_objects/seniors_app_page.yaml
@@ -114,3 +114,4 @@ seniors_app_notifications:
   new_tab: "**/XCUIElementTypeStaticText[`label == 'New'`]"
   appointment_header_modal: "**/XCUIElementTypeStaticText[`label BEGINSWITH 'Appointment'`][-1]"
   appointment_starting_soon_header_modal: "**/XCUIElementTypeStaticText[`label BEGINSWITH 'Appointment' and label ENDSWITH 'Soon'`][-1]"
+  appointment_based_on_name_element: "**/XCUIElementTypeOther[`label CONTAINS '$AND_CLI_UNIQUE_EVENT_NAME$'`][-1]"


### PR DESCRIPTION
This PR has been created to automate the following test:
https://digitalscientists.atlassian.net/browse/CXTB-22

- Added test
- Added Page Objects elements.
- Created a method to calculate the minutes that have passed since the event was sent to the senior.
- Added an step to get the time when the event was sent from the care platform on an existing helper case.

Proof of successful run:
<img width="1309" alt="image" src="https://user-images.githubusercontent.com/118279681/217851276-7ec9a7f5-11a3-4694-8c52-fdef42885682.png">
